### PR TITLE
add to sites-using-linkita list

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,5 +728,6 @@ If you notice even the slightest ambiguity or bug in this repo, report it IMMEDI
 
 - [Zola Themes Collection](https://github.com/salif/zola-themes-collection)
 - [salif.eu](https://github.com/salif/personal-web-page): Personal website
+- [Rratic's blog](https://github.com/Rratic/rratic.github.io): Personal website
 
 If your blog uses Linkita and is open source, feel free to create a pull request to add it to this list.


### PR DESCRIPTION
I'm goind to write blogs in this repo for the following years.

By the way, none of the features tags listing at the bottom of the page, toc at the top and giscus is working on my site. I carefully checked the example in your demo but didn't find where the problem is, may you help me check it?