### PR TITLE
feat: Sorting on Taxonomy Pages and Newtab Configuration in projects shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,13 +351,15 @@ taxonomies = [
 ]
 ```
 
-By default, taxonomy pages are sorted in ascending order by the number of posts. You can customize this behavior using the `extra.taxonomy_sort_reverse` setting:
+By default, taxonomy pages are sorted in descending order by the number of posts. You can customize this behavior using the `extra.taxonomy_sorting` setting:
 
 ```toml ,name=config.toml
-[extra.taxonomy_sort_reverse]
-categories = true
-tags = true
-authors = false
+[extra.taxonomy_sorting]
+# "ascending_frequency", "descending_frequency" or "name"
+# Default value: "descending_frequency"
+categories = "name"
+tags = "descending_frequency"
+authors = "name"
 ```
 
 ### General config

--- a/README.md
+++ b/README.md
@@ -351,6 +351,15 @@ taxonomies = [
 ]
 ```
 
+By default, taxonomy pages are sorted in ascending order by the number of posts. You can customize this behavior using the `extra.taxonomy_sort_reverse` setting:
+
+```toml ,name=config.toml
+[extra.taxonomy_sort_reverse]
+categories = true
+tags = true
+authors = false
+```
+
 ### General config
 
 ```toml ,name=config.toml

--- a/templates/shortcodes/projects.html
+++ b/templates/shortcodes/projects.html
@@ -34,7 +34,7 @@
       <a
         class="underline"
         href="{{ m_url::get(url=link.url) }}"
-        target="_blank"
+        {% if link.newtab or link.newtab is not defined %}target="_blank"{% endif %}
         >{{ link.name }}</a
       >
       {%- endfor %}

--- a/templates/taxonomy_list.html
+++ b/templates/taxonomy_list.html
@@ -3,10 +3,13 @@
 <h1 class="mb-16">{{ m_i18n::get_taxonomy_title(key=taxonomy.name, lk=g_lang_k, d=g_trans_d) }}</h1>
 <div class="not-prose grid grid-cols-1 gap-4 md:grid-cols-2">
   {%- set word_more = m_i18n::tr(key=`word_more`, lk=g_lang_k, d=g_trans_d) %}
-  {%- set should_reverse = config.extra.taxonomy_sort_reverse[taxonomy.name] | default(value=false) %}
-  {%- set sorted_terms = terms | sort(attribute="pages") %}
-  {%- if should_reverse %}
-    {%- set sorted_terms = sorted_terms | reverse %}
+  {%- set taxonomy_sorting = config.extra.taxonomy_sorting[taxonomy.name] | default(value="descending_frequency") %}
+  {%- if taxonomy_sorting == "ascending_frequency" %}
+    {%- set sorted_terms = terms | sort(attribute="pages") %}
+  {%- elif taxonomy_sorting == "name" %}
+    {%- set sorted_terms = terms | sort(attribute="name") %}
+  {%- else %}
+    {%- set sorted_terms = terms | sort(attribute="pages") | reverse %}
   {%- endif %}
   {%- for term in sorted_terms %}
   <div class="block-bg flex h-full flex-col rounded-lg px-5 pb-2 md:min-h-72">

--- a/templates/taxonomy_list.html
+++ b/templates/taxonomy_list.html
@@ -3,7 +3,12 @@
 <h1 class="mb-16">{{ m_i18n::get_taxonomy_title(key=taxonomy.name, lk=g_lang_k, d=g_trans_d) }}</h1>
 <div class="not-prose grid grid-cols-1 gap-4 md:grid-cols-2">
   {%- set word_more = m_i18n::tr(key=`word_more`, lk=g_lang_k, d=g_trans_d) %}
-  {%- for term in terms %}
+  {%- set should_reverse = config.extra.taxonomy_sort_reverse[taxonomy.name] | default(value=false) %}
+  {%- set sorted_terms = terms | sort(attribute="pages") %}
+  {%- if should_reverse %}
+    {%- set sorted_terms = sorted_terms | reverse %}
+  {%- endif %}
+  {%- for term in sorted_terms %}
   <div class="block-bg flex h-full flex-col rounded-lg px-5 pb-2 md:min-h-72">
     <h2 class="my-4 text-xl font-bold text-black dark:text-white">
       <a class="primary-link" href="{{ m_url::rel(there=term.permalink, here=g_here, base=g_base) }}">{%


### PR DESCRIPTION
In my customisation I found these two features quite helpful, and since they are both relatively small changes I put them into one PR. Please let me know if you'd prefer them split into two.

Changes:

- In taxonomy pages (e.g., `/tags` or `/categories`), sort in ascending or descending number of posts.
  - Configurable with `extra.taxonomy_sort_reverse`
  - Defaulting to ascending order like before
  - Updated README to reflect this
- In projects shortcode, allow links to be opened in the same tab (i.e., removing `target="_blank"`)
  - Configurable with `link.newtab` for each link
  - Defaulting to newtab like before

Thank you.